### PR TITLE
fix to element id having trouble with int64 casts in dynamo 2.0

### DIFF
--- a/archilab/Revit/Selection/Selection.cs
+++ b/archilab/Revit/Selection/Selection.cs
@@ -137,7 +137,9 @@ namespace archilab.Revit.Selection
                     e = ((string)id).Length > 8 ? doc.GetElement((string)id) : doc.GetElement(new Autodesk.Revit.DB.ElementId(int.Parse((string)id)));
                     break;
                 case TypeCode.Int32:
-                    e = doc.GetElement(new Autodesk.Revit.DB.ElementId((int)id));
+                case TypeCode.Int64:
+                case TypeCode.Int16:
+                    e = doc.GetElement(new Autodesk.Revit.DB.ElementId(int.Parse(id.ToString())));
                     break;
                 default:
                     e = doc.GetElement((Autodesk.Revit.DB.ElementId)id);


### PR DESCRIPTION
This solves the issue when `(int)` cast was failing for `int64`